### PR TITLE
Remove reference to specific TgSmush struct

### DIFF
--- a/TgSmush2/TgSmush/SharedMem.cpp
+++ b/TgSmush2/TgSmush/SharedMem.cpp
@@ -44,7 +44,7 @@ SharedMem<T>::SharedMem(LPCWSTR name, bool openOrCreate)
 		return;
 	}
 
-	pSharedData = (SharedMemData*)MapViewOfFile(
+	pSharedData = (T*)MapViewOfFile(
 		hMapFile,   // handle to map object
 		FILE_MAP_ALL_ACCESS, // read/write permission
 		0,


### PR DESCRIPTION
Hi @JeremyAnsel ,

While trying to reuse your nice and tidy code for shared memory in ddraw (nice idea with Templates), I noticed there is a reference to a specific 
struct for TgSmush(SharedMemData) in the Template definition.
The code works fine because SharedMemData is the only actual struct used, but it should be "T" instead for re-usability, right?